### PR TITLE
Fix license URI in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ requests from non-members.
 
 ## License
 This project is licensed under the terms of the IMS Global Learning Consortium Specification Document 
-License. See the [LICENSE](./LICENSE.md) file for details.
+License. See the [LICENSE](./LICENSE) file for details.
 
 ## QTI Related Repos:
 


### PR DESCRIPTION
Currently, the LICENSE link in the readme links to LICENSE.md, which does not exist. Fixed the link to just directly reference the LICENSE file